### PR TITLE
Change shebang to '#!/usr/bin/env python'

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import absolute_import, print_function
 


### PR DESCRIPTION
Making the assumption that python is at /usr/bin/python doesn't work
for people using custom python environments (i.e. pyenv)