### PR TITLE
Allow security-credentials without a trailing slash

### DIFF
--- a/metadata/routes.py
+++ b/metadata/routes.py
@@ -46,7 +46,7 @@ def instance_type():
     response.content_type = 'text/plain; charset=UTF-8'
     return 'r3.2xlarge'
 
-
+@route('/latest/meta-data/iam/security-credentials')
 @route('/latest/meta-data/iam/security-credentials/')
 def list_profiles():
     response.content_type = 'text/plain; charset=UTF-8'


### PR DESCRIPTION
Allow requesting `/latest/meta-data/iam/security-credentials` without a trailing slash. [aws-sdk-go](https://github.com/aws/aws-sdk-go) makes such request and fails. This fix works for both aws-sdk-go and aws-cli.